### PR TITLE
GCS reports "MB" but the measure is "MiB"

### DIFF
--- a/storage-cmdline-sample/src/main/java/com/google/api/services/samples/storage/cmdline/StorageSample.java
+++ b/storage-cmdline-sample/src/main/java/com/google/api/services/samples/storage/cmdline/StorageSample.java
@@ -88,7 +88,7 @@ public class StorageSample {
       View.show(object);
 
       View.header1("Uploading object.");
-      final long objectSize = 100 * 1000 * 1000 /* 100 MB */;
+      final long objectSize = 100 * 1024 * 1024 /* 100 MB */;
       InputStream data = new Helpers.RandomDataBlockInputStream(objectSize, 1024);
       object = new StorageObject()
           .setBucket(settings.getBucket())


### PR DESCRIPTION
An objectSize of 10x1000x1000 == 100MB.

GCS uses MiB but (per convention) reports this as ~= 95MB (sic.).

To get the object to list in GCS as 100MB, we need to create an objectSize of 10x1024x1024 instead.