### PR TITLE
Fix mis-matched header tags

### DIFF
--- a/calendar-appengine-sample/src/main/java/com/google/api/services/samples/calendar/appengine/server/OAuth2Callback.java
+++ b/calendar-appengine-sample/src/main/java/com/google/api/services/samples/calendar/appengine/server/OAuth2Callback.java
@@ -46,7 +46,7 @@ public class OAuth2Callback extends AbstractAppEngineAuthorizationCodeCallbackSe
       HttpServletRequest req, HttpServletResponse resp, AuthorizationCodeResponseUrl errorResponse)
       throws ServletException, IOException {
     String nickname = UserServiceFactory.getUserService().getCurrentUser().getNickname();
-    resp.getWriter().print("<h3>" + nickname + ", why don't you want to play with me?</h1>");
+    resp.getWriter().print("<h3>" + nickname + ", why don't you want to play with me?</h3>");
     resp.setStatus(200);
     resp.addHeader("Content-Type", "text/html");
   }


### PR DESCRIPTION
The header tags for the error message used an opening h3 tag and closing h1 header tag. This changes the opening and closing tags to both be h3.